### PR TITLE
Conversation history

### DIFF
--- a/service/src/main/java/com/derpgroup/quip/CommonMetadataMixIn.java
+++ b/service/src/main/java/com/derpgroup/quip/CommonMetadataMixIn.java
@@ -1,0 +1,14 @@
+package com.derpgroup.quip;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+
+@JsonTypeInfo(use = Id.NAME, include = JsonTypeInfo.As.PROPERTY, property="type", defaultImpl = QuipMetadata.class)
+@JsonSubTypes({
+  @Type(value = QuipMetadata.class)
+})
+public abstract class CommonMetadataMixIn {
+
+}

--- a/service/src/main/java/com/derpgroup/quip/MixInModule.java
+++ b/service/src/main/java/com/derpgroup/quip/MixInModule.java
@@ -1,0 +1,18 @@
+package com.derpgroup.quip;
+
+import com.derpgroup.derpwizard.voice.model.CommonMetadata;
+import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+public class MixInModule extends SimpleModule {
+  
+  public MixInModule(){
+    super("QuipModule"); 
+  }
+  
+  @Override
+   public void setupModule(SetupContext context)
+     {
+       context.setMixInAnnotations(CommonMetadata.class, CommonMetadataMixIn.class);
+    }
+}

--- a/service/src/main/java/com/derpgroup/quip/QuipMetadata.java
+++ b/service/src/main/java/com/derpgroup/quip/QuipMetadata.java
@@ -4,7 +4,11 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.derpgroup.derpwizard.voice.model.CommonMetadata;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 
+
+@JsonTypeInfo(use = Id.NAME, include = JsonTypeInfo.As.PROPERTY, property="type", defaultImpl = QuipMetadata.class)
 public class QuipMetadata extends CommonMetadata {
   
   private String bot;

--- a/service/src/main/java/com/derpgroup/quip/bots/complibot/resource/CompliBotAlexaResource.java
+++ b/service/src/main/java/com/derpgroup/quip/bots/complibot/resource/CompliBotAlexaResource.java
@@ -46,6 +46,7 @@ import com.derpgroup.derpwizard.voice.model.VoiceMessageFactory;
 import com.derpgroup.derpwizard.voice.model.VoiceOutput;
 import com.derpgroup.derpwizard.voice.model.VoiceInput.MessageType;
 import com.derpgroup.derpwizard.voice.model.VoiceMessageFactory.InterfaceType;
+import com.derpgroup.quip.MixInModule;
 import com.derpgroup.quip.QuipMetadata;
 import com.derpgroup.quip.configuration.MainConfig;
 import com.derpgroup.quip.manager.QuipManager;
@@ -88,6 +89,7 @@ public class CompliBotAlexaResource {
     sessionAttributes.put("bot", "complibot");
 
     ObjectMapper mapper = new ObjectMapper();
+    mapper.registerModule(new MixInModule());
     QuipMetadata metadata = mapper.convertValue(sessionAttributes, new TypeReference<QuipMetadata>(){});
     
     SsmlDocumentBuilder builder = new SsmlDocumentBuilder(UNSUPPORTED_SSML_TAGS);

--- a/service/src/main/java/com/derpgroup/quip/manager/QuipManager.java
+++ b/service/src/main/java/com/derpgroup/quip/manager/QuipManager.java
@@ -5,10 +5,16 @@ import java.util.Random;
 import com.derpgroup.derpwizard.manager.AbstractManager;
 import com.derpgroup.derpwizard.voice.model.SsmlDocumentBuilder;
 import com.derpgroup.derpwizard.voice.model.VoiceInput;
+import com.derpgroup.quip.MixInModule;
 import com.derpgroup.quip.QuipMetadata;
 
 public class QuipManager extends AbstractManager {
-
+  
+  public QuipManager(){
+    super();
+    mapperModule = new MixInModule();
+  }
+  
   private void doInsultRequest(VoiceInput voiceInput, SsmlDocumentBuilder builder, QuipMetadata metadata) {
     Insults insult = Insults.getRandomInsult();
     metadata.getInsultsUsed().add(insult.name());


### PR DESCRIPTION
Dependent on #8 and #9 as well as derpwizard#11.

This basically sets all of the Jackson annotations necessary to deserialize conversation history properly when it was generated from Quip.  It uses the @JsonTypeInfo and @JsonSubTypes annotations on QuipMetadata, as well as on a MixIn for CommonMetadata.
